### PR TITLE
fix: remove deprecated Stripe product API params

### DIFF
--- a/functions/create-checkout-session.ts
+++ b/functions/create-checkout-session.ts
@@ -18,8 +18,6 @@ const processDelivery = async () => {
     deliveryProduct = await stripe.products.create({
       name: 'Delivery',
       id: STRIPE_DELIVERY_PRODUCT,
-      type: 'good',
-      attributes: ['name', 'destination'],
     });
   }
 };

--- a/functions/product.ts
+++ b/functions/product.ts
@@ -35,8 +35,6 @@ const processProduct = async ({ id, title, active }: ProcessProduct) => {
   return await stripe.products.create({
     ...productFields,
     id,
-    type: 'good',
-    attributes: ['name'],
   });
 };
 


### PR DESCRIPTION
## Summary
- Remove deprecated `type: 'good'` and `attributes` params from Stripe product creation
- Fixes Contentful → Stripe webhook sync that was failing when new products were published

## Context
The Contentful webhook handler (`functions/product.ts`) creates Stripe products when new products are published in Contentful. Stripe deprecated `type: 'good'` and `attributes` in their Products API, causing product creation to fail silently. This is why the "CIRCLES OF LIFE T-Shirt" wasn't appearing on the shop page.

## Test plan
- [ ] Merge and deploy to Netlify
- [ ] Re-publish the T-Shirt product in Contentful to trigger the webhook
- [ ] Verify the product appears in Stripe
- [ ] Trigger a Netlify rebuild and verify the product appears on /shop/

🤖 Generated with [Claude Code](https://claude.com/claude-code)